### PR TITLE
Add getAvailableFunds method

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ console.log(creationRequestResponse);
 
 Gift cards can be canceled as long as they remain unclaimed by an Amazon customer. Note that this operation is only possible within 15 minutes of the creation request timestamp.
 
+### Getting Available Funds
+
+You can get the available funds in your Amazon Incentives account.
+
+```typescript
+const availableFundsResponse = await client.getAvailableFunds();
+
+console.log(availableFundsResponse);
+```
+
 ```javascript
 const cancelRequestResponse = await client.cancelGiftCard(
   'YOUR_UNIQUE_REQUEST_ID'

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,6 +181,25 @@ export namespace IncentivesAPI {
     status: string;
   }
 
+  /**
+   * See details: https://developer.amazon.com/ja/docs/incentives-api/balance-view.html#requests
+   */
+  export interface GetAvailableFundsRequest {
+    partnerId: string;
+  }
+
+  /**
+   * See details: https://developer.amazon.com/ja/docs/incentives-api/balance-view.html#requests
+   */
+  export interface GetAvailableFundsResponse {
+    availableFunds: {
+      amount: number;
+      currencyCode: string;
+    };
+    status: string;
+    timestamp: string;
+  }
+
   export interface GiftCardInfo {
     cardStatus: string;
     value: GiftCardValue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,8 +73,24 @@ export class IncentivesAPI {
     >('CancelGiftCard', createGiftCardRequest);
   }
 
+  /**
+   * Get the current balance of available funds in your Amazon Incentives account.
+   * Important: This operation is throttled at one transaction per second.
+   * Attempts to send requests at a greater rate will be ignored.
+   * See details: https://developer.amazon.com/ja/docs/incentives-api/balance-view.html#getavailablefunds
+   */
+  async getAvailableFunds(): Promise<IncentivesAPI.GetAvailableFundsResponse> {
+    const getAvailableFundsRequest: IncentivesAPI.GetAvailableFundsRequest = {
+      partnerId: this.partnerId,
+    };
+    return this.sendAwsSignedRequest<
+      IncentivesAPI.GetAvailableFundsRequest,
+      IncentivesAPI.GetAvailableFundsResponse
+    >('GetAvailableFunds', getAvailableFundsRequest);
+  }
+
   private async sendAwsSignedRequest<Request, Response>(
-    operation: 'CreateGiftCard' | 'CancelGiftCard',
+    operation: 'CreateGiftCard' | 'CancelGiftCard' | 'GetAvailableFunds',
     requestParams: Request
   ): Promise<Response> {
     const signedRequest = aws4.sign(


### PR DESCRIPTION
## Overview

First of all, I want to express my gratitude for your amazing work on the `amazon-incentives-api` package. It has been incredibly helpful for our project, and I deeply appreciate the effort and dedication you've put into maintaining it.

In our recent project, we needed to check the available funds for Amazon Incentives. We noticed that the current version of the package does not include a method for the `/GetAvailableFunds` endpoint. Therefore, we humbly suggest an enhancement by adding a `getAvailableFunds` method.

### Changes Introduced

- New Method: Added `getAvailableFunds` method to call the `/GetAvailableFunds` endpoint.
- Interfaces: Added `GetAvailableFundsRequest` and `GetAvailableFundsResponse` interfaces to define the request and response structure for the new method.
- Operation Addition: Updated `sendAwsSignedRequest` method to include `GetAvailableFunds` as a valid operation.

The `getAvailableFunds` method allows users to retrieve the available funds balance associated with their Amazon Incentives account. This functionality is crucial for applications that need to monitor and manage gift card balances programmatically.